### PR TITLE
Add cross compatibility for command 'rm'

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "NODE_ENV=DEV ./node_modules/.bin/nodemon --watch '**/*.ts' --exec './node_modules/.bin/ts-node' Index.ts",
     "test": "./node_modules/.bin/_mocha --timeout 20000 ./node_modules/.bin/_ts-node test/TestRouter.ts",
     "build": "npm run clean && ./node_modules/.bin/tsc --outDir dist",
-    "clean": "rm -rf dist"
+    "clean": "rimraf dist"
   },
   "keywords": [
     "node",
@@ -46,10 +46,12 @@
   "devDependencies": {
     "@types/chai": "^4.0.1",
     "@types/mocha": "^2.2.41",
+    "@types/rimraf": "2.0.2",
     "@types/superagent": "^3.5.1",
     "chai": "^4.0.2",
     "mocha": "^5.0.0",
     "nodemon": "^1.11.0",
+    "rimraf": "^2.6.2",
     "tslint": "^5.9.1"
   }
 }


### PR DESCRIPTION
Add compatibility of remove file with use 'rimraf' module that remplace 'rm' command to be compatible in windows, linux, Mac.